### PR TITLE
Refactor on_message HMR internals

### DIFF
--- a/src/exts/on_message.py
+++ b/src/exts/on_message.py
@@ -9,16 +9,15 @@ if typing.TYPE_CHECKING:
     from src.bot import Bot
 
 
-async def on_message(self: Bot, message: discord.Message):
-    await self.process_commands(message)
+async def on_message(bot: Bot, message: discord.Message):
+    await bot.process_commands(message)
 
 
-# TODO: refactor so that `overridden_on_message` is not externally depended on
 async def setup(bot: Bot):
-    bot.overridden_on_message = on_message
+    bot.on_message = on_message
 
 
 async def teardown(bot: Bot):
     disable_overridden_on_message = None
 
-    bot.overridden_on_message = disable_overridden_on_message
+    bot.on_message = disable_overridden_on_message


### PR DESCRIPTION
This is a minor change where instead of relying on an overridden on_message definition, an internal property is utilised instead.

Later on, this will be paving a way for future event handling and event HMR in general.
